### PR TITLE
fix bounding box volume root tile calculation

### DIFF
--- a/py3dtiles/bounding_volume_box.py
+++ b/py3dtiles/bounding_volume_box.py
@@ -108,7 +108,6 @@ class BoundingVolumeBox(ThreeDTilesNotion, BoundingVolume, object):
         y_max = mins_maxs[4]
         z_min = mins_maxs[2]
         z_max = mins_maxs[5]
-        # print("coucou")
         new_center = numpy.array([(x_min + x_max) / 2,
                                (y_min + y_max) / 2,
                                (z_min + z_max) / 2])

--- a/py3dtiles/bounding_volume_box.py
+++ b/py3dtiles/bounding_volume_box.py
@@ -108,7 +108,7 @@ class BoundingVolumeBox(ThreeDTilesNotion, BoundingVolume, object):
         y_max = mins_maxs[4]
         z_min = mins_maxs[2]
         z_max = mins_maxs[5]
-
+        # print("coucou")
         new_center = numpy.array([(x_min + x_max) / 2,
                                (y_min + y_max) / 2,
                                (z_min + z_max) / 2])
@@ -243,7 +243,6 @@ class BoundingVolumeBox(ThreeDTilesNotion, BoundingVolume, object):
             return
         # We reset to some dummy state of this Bounding Volume Box so we
         # can add up in place the boxes of the owner's children
-        self.set_from_list([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])
         print("Warning: overwriting box bounding volume.")
         for child in owner.get_children():
             # FIXME have the transform method return a new object and


### PR DESCRIPTION
Referring to [this issue](https://github.com/VCityTeam/py3dtilers/issues/9), there was a need to fix the bounding box calculation.

After few checks, by default, the root tile was set to [0,0,0], even if the tileset does not contain an object near this position.
When computing the root tile from its children, only their bounding box must be taken into  account