### PR TITLE
Write simple material in gltf header

### DIFF
--- a/py3dtiles/__init__.py
+++ b/py3dtiles/__init__.py
@@ -11,6 +11,7 @@ from .batch_table_hierarchy_extension import BatchTableHierarchy
 from .bounding_volume import BoundingVolume
 from .bounding_volume_box import BoundingVolumeBox
 from .feature_table import Feature
+from .gltf_material import GlTFMaterial
 from .gltf import GlTF
 from .temporal_extension_batch_table import TemporalBatchTable
 from .temporal_extension_bounding_volume import TemporalBoundingVolume
@@ -39,6 +40,7 @@ __all__ = ['B3dm',
            'SchemaValidators',
            'Extension',
            'Feature',
+           'GlTFMaterial',
            'GlTF',
            'Pnts',
            'TemporalBatchTable',

--- a/py3dtiles/gltf.py
+++ b/py3dtiles/gltf.py
@@ -73,7 +73,7 @@ class GlTF(object):
 
     @staticmethod
     def from_binary_arrays(arrays, transform, binary=True, batched=True,
-                           uri=None, textureUri=None, material=GlTFMaterial()):
+                           uri=None, materials=[GlTFMaterial()]):
         """
         Parameters
         ----------
@@ -84,6 +84,7 @@ class GlTF(object):
             arrays['uv']: binary array of vertex texture coordinates
                           (Not implemented yet)
             arrays['bbox']: geometry bounding box (numpy.array)
+            arrays['matIndex']: the index of the material used by the geometry
 
         transform : numpy.array
             World coordinates transformation flattend matrix
@@ -102,6 +103,7 @@ class GlTF(object):
         binUvs = []
         nVertices = []
         bb = []
+        matIndexes = []
         batchLength = 0
         for i, geometry in enumerate(arrays):
             binVertices.append(geometry['position'])
@@ -109,6 +111,7 @@ class GlTF(object):
             n = round(len(geometry['position']) / 12)
             nVertices.append(n)
             bb.append(geometry['bbox'])
+            matIndexes.append(geometry['matIndex'])
             if batched:
                 binIds.append(np.full(n, i, dtype=np.float32))
             if textured:
@@ -133,8 +136,7 @@ class GlTF(object):
             bb = [[[minx, miny, minz], [maxx, maxy, maxz]]]
 
         glTF.header = compute_header(binVertices, nVertices, bb, transform,
-                                     textured, batched, batchLength, uri,
-                                     textureUri, material)
+                                     textured, batched, batchLength, uri, materials, matIndexes)
         glTF.body = np.frombuffer(compute_binary(binVertices, binNormals,
                                   binIds, binUvs), dtype=np.uint8)
 
@@ -150,7 +152,7 @@ def compute_binary(binVertices, binNormals, binIds, binUvs):
 
 
 def compute_header(binVertices, nVertices, bb, transform,
-                   textured, batched, batchLength, uri, textureUri, materialProps):
+                   textured, batched, batchLength, uri, meshMaterials, materialIndexes):
     # Buffer
     meshNb = len(binVertices)
     sizeVce = []
@@ -253,7 +255,7 @@ def compute_header(binVertices, nVertices, bb, transform,
                     "POSITION": nAttributes * i,
                     "NORMAL": nAttributes * i + 1
                 },
-                "material": 0,
+                "material": materialIndexes[i],
                 "mode": 4
             }]
         })
@@ -272,14 +274,13 @@ def compute_header(binVertices, nVertices, bb, transform,
         })
 
     # Materials
-    materials = [{
-        'pbrMetallicRoughness': {
-            'baseColorFactor': materialProps.rgba,
-            'metallicFactor': materialProps.metallicFactor,
-            'roughnessFactor': materialProps.roughnessFactor
-        },
-        'name': 'Material',
-    }]
+    images = []
+    materials = []
+    for i, mat in enumerate(meshMaterials):
+        material = mat.to_dict('Material' + str(i), len(images))
+        if mat.is_textured():
+            images.append({'uri': mat.textureUri})
+        materials.append(material)
 
     # Final glTF
     header = {
@@ -305,17 +306,12 @@ def compute_header(binVertices, nVertices, bb, transform,
             'sampler': 0,
             'source': 0
         }]
-        header['images'] = [{
-            'uri': textureUri
-        }]
+        header['images'] = images
         header['samplers'] = [{
             "magFilter": 9729,
             "minFilter": 9987,
             "wrapS": 10497,
             "wrapT": 10497
         }]
-        header['materials'][0]['pbrMetallicRoughness']['baseColorTexture'] = {
-            'index': 0
-        }
 
     return header

--- a/py3dtiles/gltf.py
+++ b/py3dtiles/gltf.py
@@ -2,6 +2,7 @@
 import struct
 import numpy as np
 import json
+from .gltf_material import GlTFMaterial
 
 
 class GlTF(object):
@@ -72,7 +73,7 @@ class GlTF(object):
 
     @staticmethod
     def from_binary_arrays(arrays, transform, binary=True, batched=True,
-                           uri=None, textureUri=None):
+                           uri=None, textureUri=None, material=GlTFMaterial()):
         """
         Parameters
         ----------
@@ -133,7 +134,7 @@ class GlTF(object):
 
         glTF.header = compute_header(binVertices, nVertices, bb, transform,
                                      textured, batched, batchLength, uri,
-                                     textureUri)
+                                     textureUri, material)
         glTF.body = np.frombuffer(compute_binary(binVertices, binNormals,
                                   binIds, binUvs), dtype=np.uint8)
 
@@ -149,7 +150,7 @@ def compute_binary(binVertices, binNormals, binIds, binUvs):
 
 
 def compute_header(binVertices, nVertices, bb, transform,
-                   textured, batched, batchLength, uri, textureUri):
+                   textured, batched, batchLength, uri, textureUri, materialProps):
     # Buffer
     meshNb = len(binVertices)
     sizeVce = []
@@ -273,7 +274,9 @@ def compute_header(binVertices, nVertices, bb, transform,
     # Materials
     materials = [{
         'pbrMetallicRoughness': {
-            'metallicFactor': 0
+            'baseColorFactor': materialProps.rgba,
+            'metallicFactor': materialProps.metallicFactor,
+            'roughnessFactor': materialProps.roughnessFactor
         },
         'name': 'Material',
     }]

--- a/py3dtiles/gltf_material.py
+++ b/py3dtiles/gltf_material.py
@@ -65,9 +65,7 @@ class GlTFMaterial():
 
     @staticmethod
     def from_hexa(color_code='#FFFFFF'):
-        material = GlTFMaterial()
         hex = color_code.replace('#', '').replace('0x', '')
         rgb = [int(hex[i:i + 2], 16) / 255 for i in (0, 2, 4)]
-        material.rgba = rgb
 
-        return material
+        return GlTFMaterial(rgb=rgb)

--- a/py3dtiles/gltf_material.py
+++ b/py3dtiles/gltf_material.py
@@ -66,6 +66,7 @@ class GlTFMaterial():
     @staticmethod
     def from_hexa(color_code='#FFFFFF'):
         hex = color_code.replace('#', '').replace('0x', '')
-        rgb = [int(hex[i:i + 2], 16) / 255 for i in (0, 2, 4)]
+        length = max(len(hex), 8)
+        rgb = [int(hex[i:i + 2], 16) / 255 for i in range(0, length, 2)]
 
         return GlTFMaterial(rgb=rgb)

--- a/py3dtiles/gltf_material.py
+++ b/py3dtiles/gltf_material.py
@@ -1,0 +1,73 @@
+class GlTFMaterial():
+    def __init__(self, metallicFactor=0, roughnessFactor=0, rgb=[1, 1, 1], alpha=1):
+        self.metallicFactor = metallicFactor
+        self.roughnessFactor = roughnessFactor
+        self.rgba = rgb
+        if len(rgb) < 4:
+            self.alpha = alpha
+
+    @property
+    def metallicFactor(self):
+        return self._metallicFactor
+
+    @metallicFactor.setter
+    def metallicFactor(self, value):
+        if value > 1:
+            value = 1
+        if value < 0:
+            value = 0
+        self._metallicFactor = value
+
+    @property
+    def roughnessFactor(self):
+        return self._roughnessFactor
+
+    @roughnessFactor.setter
+    def roughnessFactor(self, value):
+        if value > 1:
+            value = 1
+        if value < 0:
+            value = 0
+        self._roughnessFactor = value
+
+    @property
+    def rgba(self):
+        return self._rgba
+
+    @rgba.setter
+    def rgba(self, values):
+        for value in values:
+            if value > 1:
+                value /= 255
+            if value < 0:
+                value = abs(value / 255)
+        if len(values) < 3:
+            for i in range(len(values), 3):
+                values.append(0)
+        elif len(values) > 4:
+            values = values[:4]
+        self._rgba = values
+
+    @property
+    def alpha(self):
+        return self._rgba[3]
+
+    @alpha.setter
+    def alpha(self, value):
+        if value > 1:
+            value /= 255
+        if value < 0:
+            value = abs(value / 255)
+        if len(self._rgba) < 4:
+            self._rgba.append(value)
+        else:
+            self._rgba[3] = value
+
+    @staticmethod
+    def from_hexa(color_code='#FFFFFF'):
+        material = GlTFMaterial()
+        hex = color_code.replace('#', '').replace('0x', '')
+        rgb = [int(hex[i:i + 2], 16) / 255 for i in (0, 2, 4)]
+        material.rgba = rgb
+
+        return material

--- a/py3dtiles/gltf_material.py
+++ b/py3dtiles/gltf_material.py
@@ -3,12 +3,13 @@ import sys
 
 
 class GlTFMaterial():
-    def __init__(self, metallicFactor=0, roughnessFactor=0, rgb=[1, 1, 1], alpha=1):
+    def __init__(self, metallicFactor=0, roughnessFactor=0, rgb=[1, 1, 1], alpha=1, textureUri=None):
         self.metallicFactor = metallicFactor
         self.roughnessFactor = roughnessFactor
         self.rgba = rgb
         if len(rgb) < 4:
             self.alpha = alpha
+        self.textureUri = textureUri
 
     @property
     def metallicFactor(self):
@@ -50,6 +51,21 @@ class GlTFMaterial():
             self._rgba.append(value)
         else:
             self._rgba[3] = value
+
+    def is_textured(self):
+        return self.textureUri is not None
+
+    def to_dict(self, name, index=0):
+        dictionary = {
+            'pbrMetallicRoughness': {
+                'baseColorFactor': self.rgba,
+                'metallicFactor': self.metallicFactor,
+                'roughnessFactor': self.roughnessFactor
+            },
+            'name': name}
+        if self.is_textured():
+            dictionary['baseColorTexture'] = {'index': index}
+        return dictionary
 
     @staticmethod
     def from_hexa(color_code='#FFFFFF'):

--- a/py3dtiles/gltf_material.py
+++ b/py3dtiles/gltf_material.py
@@ -1,3 +1,7 @@
+import numpy as np
+import sys
+
+
 class GlTFMaterial():
     def __init__(self, metallicFactor=0, roughnessFactor=0, rgb=[1, 1, 1], alpha=1):
         self.metallicFactor = metallicFactor
@@ -12,11 +16,7 @@ class GlTFMaterial():
 
     @metallicFactor.setter
     def metallicFactor(self, value):
-        if value > 1:
-            value = 1
-        if value < 0:
-            value = 0
-        self._metallicFactor = value
+        self._metallicFactor = self.normalize_value(value, max(1, value))
 
     @property
     def roughnessFactor(self):
@@ -24,11 +24,7 @@ class GlTFMaterial():
 
     @roughnessFactor.setter
     def roughnessFactor(self, value):
-        if value > 1:
-            value = 1
-        if value < 0:
-            value = 0
-        self._roughnessFactor = value
+        self._roughnessFactor = self.normalize_value(value, max(1, value))
 
     @property
     def rgba(self):
@@ -36,17 +32,12 @@ class GlTFMaterial():
 
     @rgba.setter
     def rgba(self, values):
-        for value in values:
-            if value > 1:
-                value /= 255
-            if value < 0:
-                value = abs(value / 255)
         if len(values) < 3:
             for i in range(len(values), 3):
                 values.append(0)
         elif len(values) > 4:
             values = values[:4]
-        self._rgba = values
+        self._rgba = self.normalize_color(values)
 
     @property
     def alpha(self):
@@ -54,10 +45,7 @@ class GlTFMaterial():
 
     @alpha.setter
     def alpha(self, value):
-        if value > 1:
-            value /= 255
-        if value < 0:
-            value = abs(value / 255)
+        value = self.normalize_value(value, self.max(value, 1, 255))
         if len(self._rgba) < 4:
             self._rgba.append(value)
         else:
@@ -66,7 +54,23 @@ class GlTFMaterial():
     @staticmethod
     def from_hexa(color_code='#FFFFFF'):
         hex = color_code.replace('#', '').replace('0x', '')
-        length = max(len(hex), 8)
+        length = min(len(hex), 8)
         rgb = [int(hex[i:i + 2], 16) / 255 for i in range(0, length, 2)]
 
         return GlTFMaterial(rgb=rgb)
+
+    @classmethod
+    def normalize_value(cls, value, max):
+        if value < 0:
+            print('The value can\'t be negative')
+            sys.exit(1)
+        return value / max
+
+    @classmethod
+    def max(cls, value, max_1, max_2):
+        return max_1 if value < max_1 else max(max_2, value)
+
+    @classmethod
+    def normalize_color(cls, color):
+        max_value = cls.max(np.max(color), 1, 255)
+        return [cls.normalize_value(value, max_value) for value in color]

--- a/tests/test_b3dm.py
+++ b/tests/test_b3dm.py
@@ -5,7 +5,7 @@ import numpy as np
 import json
 # np.set_printoptions(formatter={'int':hex})
 
-from py3dtiles import TileReader, B3dm, GlTF, TriangleSoup
+from py3dtiles import TileReader, B3dm, GlTF, TriangleSoup, GlTFMaterial
 
 
 class TestTileReader(unittest.TestCase):
@@ -38,7 +38,8 @@ class TestTileBuilder(unittest.TestCase):
         arrays = [{
             'position': positions,
             'normal': normals,
-            'bbox': box
+            'bbox': box,
+            'matIndex': 0
         }]
 
         transform = np.array([
@@ -54,7 +55,7 @@ class TestTileBuilder(unittest.TestCase):
         # get an array
         t.to_array()
         self.assertEqual(t.header.version, 1.0)
-        self.assertEqual(t.header.tile_byte_length, 3076)
+        self.assertEqual(t.header.tile_byte_length, 3080)
         self.assertEqual(t.header.ft_json_byte_length, 0)
         self.assertEqual(t.header.ft_bin_byte_length, 0)
         self.assertEqual(t.header.bt_json_byte_length, 0)
@@ -80,7 +81,8 @@ class TestTexturedTileBuilder(unittest.TestCase):
             'position': positions,
             'normal': normals,
             'uv': uvs,
-            'bbox': box
+            'bbox': box,
+            'matIndex': 0
         }]
 
         transform = np.array([
@@ -89,7 +91,7 @@ class TestTexturedTileBuilder(unittest.TestCase):
             [0, 0, 1, 0],
             [0, 0, 0, 1]], dtype=float)
         transform = transform.flatten('F')
-        glTF = GlTF.from_binary_arrays(arrays, transform, textureUri='squaretexture.jpg')
+        glTF = GlTF.from_binary_arrays(arrays, transform, materials=[GlTFMaterial(textureUri='squaretexture.jpg')])
         t = B3dm.from_glTF(glTF)
 
         # get an array

--- a/tests/test_b3dm.py
+++ b/tests/test_b3dm.py
@@ -54,7 +54,7 @@ class TestTileBuilder(unittest.TestCase):
         # get an array
         t.to_array()
         self.assertEqual(t.header.version, 1.0)
-        self.assertEqual(t.header.tile_byte_length, 2952)
+        self.assertEqual(t.header.tile_byte_length, 3000)
         self.assertEqual(t.header.ft_json_byte_length, 0)
         self.assertEqual(t.header.ft_bin_byte_length, 0)
         self.assertEqual(t.header.bt_json_byte_length, 0)
@@ -95,7 +95,7 @@ class TestTexturedTileBuilder(unittest.TestCase):
         # get an array
         t.to_array()
         self.assertEqual(t.header.version, 1.0)
-        self.assertEqual(t.header.tile_byte_length, 1556)
+        self.assertEqual(t.header.tile_byte_length, 1604)
         self.assertEqual(t.header.ft_json_byte_length, 0)
         self.assertEqual(t.header.ft_bin_byte_length, 0)
         self.assertEqual(t.header.bt_json_byte_length, 0)

--- a/tests/test_b3dm.py
+++ b/tests/test_b3dm.py
@@ -54,7 +54,7 @@ class TestTileBuilder(unittest.TestCase):
         # get an array
         t.to_array()
         self.assertEqual(t.header.version, 1.0)
-        self.assertEqual(t.header.tile_byte_length, 3000)
+        self.assertEqual(t.header.tile_byte_length, 3076)
         self.assertEqual(t.header.ft_json_byte_length, 0)
         self.assertEqual(t.header.ft_bin_byte_length, 0)
         self.assertEqual(t.header.bt_json_byte_length, 0)
@@ -95,7 +95,7 @@ class TestTexturedTileBuilder(unittest.TestCase):
         # get an array
         t.to_array()
         self.assertEqual(t.header.version, 1.0)
-        self.assertEqual(t.header.tile_byte_length, 1604)
+        self.assertEqual(t.header.tile_byte_length, 1680)
         self.assertEqual(t.header.ft_json_byte_length, 0)
         self.assertEqual(t.header.ft_bin_byte_length, 0)
         self.assertEqual(t.header.bt_json_byte_length, 0)

--- a/tests/test_tileset_simple_cube.py
+++ b/tests/test_tileset_simple_cube.py
@@ -74,7 +74,8 @@ class TestTileBuilder(unittest.TestCase, object):
         arrays = [{
             'position': ts.getPositionArray(),
             'normal': ts.getNormalArray(),
-            'bbox': ts.getBboxAsFloat()
+            'bbox': ts.getBboxAsFloat(),
+            'matIndex': 0
         }]
         # GlTF uses a y-up coordinate system, and we thus need to realize
         # a z-up to y-up coordinate transform for the cuboids to respect


### PR DESCRIPTION
Write GlTF materials in header. A material contains a base color, a roughness factor and a metallic factor. It can also contains a base color texture (index of a texture image) if the material is textured. The material follows the [GlTF material definition](https://github.com/KhronosGroup/glTF-Tutorials/blob/master/gltfTutorial/gltfTutorial_011_SimpleMaterial.md#material-definition).

This PR will allow to write 3DTiles with color. All the geometries in a tile will have a RGB color or a texture. Different geometries from the same tile can have different materials.