### PR TITLE
Force float32

### DIFF
--- a/py3dtiles/wkb_utils.py
+++ b/py3dtiles/wkb_utils.py
@@ -239,7 +239,7 @@ def vertexAttributeToArray(triangles):
     array = []
     for face in triangles:
         for vertex in face:
-            array.append(vertex)
+            array.append(np.array(vertex,dtype=np.float32))
     return array
 
 

--- a/py3dtiles/wkb_utils.py
+++ b/py3dtiles/wkb_utils.py
@@ -172,7 +172,7 @@ class TriangleSoup:
             if norm == 0:
                 normals.append(np.array([0, 0, 1], dtype=np.float32))
             else:
-                normals.append(N / norm)
+                normals.append((N / norm).astype(np.float32))
 
         verticeArray = faceAttributeToArray(normals)
         return b''.join(verticeArray)
@@ -239,7 +239,8 @@ def vertexAttributeToArray(triangles):
     array = []
     for face in triangles:
         for vertex in face:
-            array.append(np.array(vertex,dtype=np.float32))
+            array.append(vertex.astype(np.float32))
+
     return array
 
 


### PR DESCRIPTION
When getting the geometry from a TriangleSoup, it now comes as float32 just before making it a binary array to respect the specification.