### PR TITLE
Update setup.py to support higher versions of numpy and .travis.yml to node version 16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ jobs:
         - py3dtiles info tests/pointCloudRGB.pnts
     - stage: "Markdown link checks"
       language: node_js
-      node_js: 14
+      node_js: 16
       script:
         - npm install --global remark-cli remark-validate-links
         - remark -u validate-links .

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages
 here = os.path.abspath(os.path.dirname(__file__))
 
 requirements = (
-    "numpy>=1.9.0,<1.21",
+    "numpy>=1.9.0,<1.25",
     "pyproj",
     "cython",
     "triangle",


### PR DESCRIPTION
I am integrating py3dtilers/py3dtiles with our application and need to allow use higher version of numpy. 